### PR TITLE
Move the readme update into a separate workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,6 @@ on:
         required: false
         type: boolean
         default: false
-      update-readme:
-        description: "Update the README.md file"
-        required: false
-        type: boolean
-        default: false
       do-release:
         description: "Build release artifacts and upload with this version"
         required: false
@@ -41,7 +36,6 @@ env:
   ACTION_VERSION: ${{ github.event.inputs.do-release || github.event.release.tag_name || '' }}
   DO_RELEASE: ${{ github.event_name == 'release' || startsWith(github.event.inputs.do-release, 'v') }}
   SIGN_MACOS: ${{ github.event_name == 'release' || github.event.inputs.sign-macos == 'true' }}
-  UPDATE_README: ${{ github.event_name == 'release' || github.event.inputs.update-readme == 'true' }}
 
 jobs:
   test:
@@ -137,12 +131,3 @@ jobs:
           file: release/server*
           tag: ${{ github.event.release.tag_name }}
           overwrite: true
-
-      - name: Update the README
-        if: env.UPDATE_README == 'true' && runner.os == 'Linux'
-        run: |
-          ./update-readme.sh ${{ github.sha }} ${{ env.ACTION_VERSION }}
-          git config --local user.email "leon@toit.io"
-          git config --local user.name "Toit CI"
-          git commit -am "Update README"
-          git push

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -1,0 +1,45 @@
+name: Update README
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Update README to given version"
+        required: true
+        type: string
+
+env:
+  ACTION_VERSION: ${{ github.event.inputs.version || github.event.release.tag_name || '' }}
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    # The repository normally doesn't allow to push directly to the main branch.
+    # This is a special case where we want to update the README with the latest
+    # hash and version number.
+    # Following https://github.com/orgs/community/discussions/25305
+    # We created an App that is just there to bypass the protection rules.
+    # In the settings of this repository, this App is excempt from the protection rules.
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app_id: ${{ vars.BYPASS_PROTECTION_APPID }}
+          private_key: ${{ secrets.BYPASS_PROTECTION_SECRET }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Update the README
+        run: |
+          ./update-readme.sh ${{ github.sha }} ${{ env.ACTION_VERSION }}
+          git config --local user.email "leon@toit.io"
+          git config --local user.name "Toit CI"
+          git commit -am "Update README"
+          git push

--- a/.github/workflows/sign.yml
+++ b/.github/workflows/sign.yml
@@ -1,7 +1,9 @@
 name: sign
 
 on:
-  workflow_dispatch
+  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   build-windows-executables:


### PR DESCRIPTION
Also use the bypass-protection app to be able to push directly to main.